### PR TITLE
pycryptodome uses Crypto now as the package name

### DIFF
--- a/gocryptfs.py
+++ b/gocryptfs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
-from Cryptodome.Protocol.KDF import HKDF
-from Cryptodome.Cipher import AES
-from Cryptodome.Hash import SHA256
+from Crypto.Protocol.KDF import HKDF
+from Crypto.Cipher import AES
+from Crypto.Hash import SHA256
 import itertools
 import argparse
 import getpass


### PR DESCRIPTION
Thanks for making this project!

pycryptodome (now?) uses the `Crypto` package name now, so this small fix is necessary to work with modern versions.

Also, please consider adding a license to this project?