### PR TITLE
use /usr/bin/env for venv compatibility

### DIFF
--- a/gocryptfs-deobfuscate.py
+++ b/gocryptfs-deobfuscate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import argparse
 import socket
 import json

--- a/gocryptfs.py
+++ b/gocryptfs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import itertools
 import argparse
 import getpass


### PR DESCRIPTION
When I install pycrypdome in my venv only I need it to not try to use my global python with that shebang. Also, `env` is coreutils so basically everyone has it